### PR TITLE
Adds an example with a REST API Axum backend

### DIFF
--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "axum"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+prisma-client-rust = { path = "../.." }
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+axum = "0.5"

--- a/examples/axum/README.md
+++ b/examples/axum/README.md
@@ -1,0 +1,59 @@
+# REST Axum Example
+
+This is an example of how you could use [Prisma Client Rust](https://github.com/Brendonovich/prisma-client-rust) in a REST API, written by [kr4xkan](https://github.com/kr4xkan). 
+
+## Running
+
+First generate the Prisma client:
+
+```
+$ cargo prisma generate
+```
+
+Setup database:
+
+```
+$ cargo prisma db push
+```
+
+Then run the server:
+
+```
+$ cargo run
+```
+
+## Notes
+
+In addition to showing you how to use this crate in a REST API backend, it also gives you a way too catch errors from Prisma in one single place.
+
+## Endpoints
+
+Base URL: `localhost:5000/api`
+
+`/user` :
+- `GET` : Lists all users
+- `POST` : Create a user
+  - ```json
+    INPUT
+    {
+        "username": string
+        "email": string
+    }
+`/user/<username>` :
+- `PUT` : Update a user
+  - ```json
+    INPUT
+    {
+        "username": string
+        "email": string
+    }
+- `DELETE` : Delete a user
+
+`/comment` :
+- `POST` : Create a comment linked to a user
+  - ```json
+    INPUT
+    {
+        "user": int
+        "message": string
+    }

--- a/examples/axum/prisma/schema.prisma
+++ b/examples/axum/prisma/schema.prisma
@@ -1,0 +1,23 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev.db"
+}
+
+generator client {
+  provider = "cargo prisma"
+  output   = "../src/db.rs"
+}
+
+model User {
+  id       Int        @id @default(autoincrement())
+  username String     @unique
+  email    String
+  comments Comments[]
+}
+
+model Comments {
+  id       Int    @id @default(autoincrement())
+  message  String
+  authorId Int
+  author   User   @relation(fields: [authorId], references: [id], onDelete: Cascade)
+}

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -1,0 +1,21 @@
+use axum::{extract::Extension, Router};
+use std::sync::Arc;
+
+pub mod db;
+pub mod routes;
+
+#[tokio::main]
+async fn main() {
+    let prisma_client = Arc::new(db::new_client().await.unwrap());
+
+    let app = Router::new()
+        .nest("/api", routes::create_route())
+        .layer(Extension(prisma_client));
+
+    println!("Example Prisma x Axum running on http://localhost:5000/api");
+
+    axum::Server::bind(&"0.0.0.0:5000".parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}

--- a/examples/axum/src/routes.rs
+++ b/examples/axum/src/routes.rs
@@ -1,0 +1,166 @@
+use axum::{
+    extract::{Json, Path},
+    routing::{get, put, post},
+    response::{IntoResponse, Response},
+    http::StatusCode,
+    Extension,
+    Router,
+};
+use prisma_client_rust::{
+    prisma_errors::query_engine::{
+        RecordNotFound,
+        UniqueKeyViolation,
+    },
+    Error,
+    error_is_type,
+};
+
+use serde::Deserialize;
+
+use crate::db::{self, user, comments};
+
+type Database = Extension<std::sync::Arc<db::PrismaClient>>;
+type AppResult<T> = Result<T, AppError>;
+type AppJsonResult<T> = AppResult<Json<T>>;
+
+// Define all your requests schema
+#[derive(Deserialize)]
+struct UserRequest {
+    username: String,
+    email: String,
+}
+
+#[derive(Deserialize)]
+struct CommentRequest {
+    user: i32,
+    message: String,
+}
+
+/*
+
+/api/user => GET, POST
+/api/user/:username => PUT, DELETE
+/comment => POST
+
+*/
+pub fn create_route() -> Router {
+    Router::new()
+        .route(
+            "/user",
+            get(handle_user_get)
+            .post(handle_user_post)
+        )
+        .route(
+            "/user/:username",
+            put(handle_user_put)
+            .delete(handle_user_delete),
+        )
+        .route("/comment", post(handle_comment_post))
+}
+
+async fn handle_user_get(db: Database) -> AppResult<Json<Vec<user::Data>>> {
+    let users = db.user()
+    .find_many(vec![])
+    .with(user::comments::fetch(vec![]))
+    .exec()
+    .await?;
+
+    Ok(Json::from(users))
+}
+
+async fn handle_user_post(
+    db: Database,
+    Json(input): Json<UserRequest>,
+) -> AppJsonResult<user::Data> {
+    let data = db.user()
+        .create(
+            user::username::set(input.username),
+            user::email::set(input.email),
+            vec![],
+        )
+        .exec()
+        .await?;
+
+    Ok(Json::from(data))
+}
+
+async fn handle_user_put(
+    db: Database,
+    Path(username): Path<String>,
+    Json(input): Json<UserRequest>,
+) -> AppJsonResult<user::Data> {
+    let result = db.user()
+        .find_unique(user::username::equals(username))
+        .update(vec![
+            user::username::set(input.username),
+            user::email::set(input.email),
+        ])
+        .exec()
+        .await?;
+    
+    match result {
+        Some(updated_user) => Ok(Json::from(updated_user)),
+        _ => Err(AppError::NotFound)
+    }
+}
+
+async fn handle_user_delete(
+    db: Database,
+    Path(username): Path<String>,
+) -> AppResult<StatusCode> {
+    db.user()
+        .find_unique(user::username::equals(username))
+        .delete()
+        .exec()
+        .await?;
+    
+    Ok(StatusCode::OK)
+}
+
+async fn handle_comment_post(
+    db: Database,
+    Json(req): Json<CommentRequest>,
+) -> AppJsonResult<comments::Data> {
+    let comment = db.comments()
+        .create(
+            comments::message::set(req.message),
+            comments::author::link(user::UniqueWhereParam::IdEquals(req.user)),
+            vec![]
+        )
+        .exec()
+        .await?;
+    
+    Ok(Json::from(comment))
+}
+
+enum AppError {
+    PrismaError(Error),
+    NotFound,
+}
+
+impl From<Error> for AppError {
+    fn from(inner: Error) -> Self {
+        AppError::PrismaError(inner)
+    }
+}
+
+// This centralizes all differents errors from our app in one place
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let status = match self {
+            AppError::PrismaError(Error::Execute(prisma_err)) => {
+                if error_is_type::<RecordNotFound>(&prisma_err) {
+                    StatusCode::NOT_FOUND
+                } else if error_is_type::<UniqueKeyViolation>(&prisma_err) {
+                    StatusCode::CONFLICT
+                } else {
+                    StatusCode::BAD_REQUEST
+                }
+            },
+            AppError::NotFound => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR
+        };
+
+        status.into_response()
+    }
+}

--- a/examples/axum/src/routes.rs
+++ b/examples/axum/src/routes.rs
@@ -7,10 +7,7 @@ use axum::{
     Router,
 };
 use prisma_client_rust::{
-    prisma_errors::query_engine::{
-        RecordNotFound,
-        UniqueKeyViolation,
-    },
+    prisma_errors::query_engine::UniqueKeyViolation,
     Error,
     error_is_type,
 };
@@ -60,10 +57,10 @@ pub fn create_route() -> Router {
 
 async fn handle_user_get(db: Database) -> AppResult<Json<Vec<user::Data>>> {
     let users = db.user()
-    .find_many(vec![])
-    .with(user::comments::fetch(vec![]))
-    .exec()
-    .await?;
+        .find_many(vec![])
+        .with(user::comments::fetch(vec![]))
+        .exec()
+        .await?;
 
     Ok(Json::from(users))
 }
@@ -149,9 +146,7 @@ impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let status = match self {
             AppError::PrismaError(Error::Execute(prisma_err)) => {
-                if error_is_type::<RecordNotFound>(&prisma_err) {
-                    StatusCode::NOT_FOUND
-                } else if error_is_type::<UniqueKeyViolation>(&prisma_err) {
+                if error_is_type::<UniqueKeyViolation>(&prisma_err) {
                     StatusCode::CONFLICT
                 } else {
                     StatusCode::BAD_REQUEST


### PR DESCRIPTION
The repo only has an example with axum combined with GraphQL.
I think it would be great to also have a more classic REST API example, so here is my proposal.

And as an added bonus it shows a way to handle Prisma errors with a centralized error handler.