### PR TITLE
fix: specify minimum rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Brendan Allan <brendonovich@outlook.com>"]
 edition = "2021"
 description = "A prisma client for Rust"
 license = "MIT"
+rust-version = "1.62"
 
 exclude = ["examples", "integration-tests"]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "prisma-client-rust-cli"
 version = "0.6.0"
 authors = ["Brendan Allan <brendonovich@outlook.com>"]
 edition = "2021"
+rust-version = "1.62"
 
 [features]
 default = []

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -3,6 +3,7 @@ name = "prisma-client-rust-sdk"
 version = "0.6.0"
 authors = ["Brendan Allan <brendonovich@outlook.com>"]
 edition = "2021"
+rust-version = "1.62"
 
 [dependencies]
 convert_case = "0.5.0"


### PR DESCRIPTION
Adds a specification for the Minimum Supported Rust Version (MSRV).
`#[derive(Default)]` on enums with a `#[default]` was added to the rust stable channel in version 1.62. 

see: 
https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
https://github.com/rust-lang/rust/pull/94457