### PR TITLE
Better rspc integration

### DIFF
--- a/cli/src/generator/models/data.rs
+++ b/cli/src/generator/models/data.rs
@@ -96,8 +96,11 @@ pub fn struct_definition(model: &dml::Model) -> TokenStream {
                 },
             };
 
+            let specta_attrs = cfg!(feature = "rspc").then(|| quote!(#[specta(skip)]));
+
             quote! {
                 #attrs
+                #specta_attrs
                 pub #field_name_snake: Option<#typ>
             }
         }

--- a/cli/src/generator/models/include.rs
+++ b/cli/src/generator/models/include.rs
@@ -339,9 +339,9 @@ pub fn generate_macro(model: &dml::Model, module_path: &TokenStream) -> TokenStr
     quote! {
         #[macro_export]
         macro_rules! #macro_name {
-            ($(($($func_arg:ident: $func_arg_ty:ty),+) =>)? $module_vis:vis $module_name:ident { $(#selection_pattern_produce)+ }) => {
+            ($(($($func_arg:ident: $func_arg_ty:ty),+) =>)? $module_name:ident { $(#selection_pattern_produce)+ }) => {
                 #[allow(warnings)]
-                $module_vis mod $module_name {
+                pub mod $module_name {
                     $crate::#module_path::#model_name_snake::include!(@definitions; $(#selection_pattern_consume)+);
 
                     pub struct Include(Vec<::prisma_client_rust::Selection>);

--- a/cli/src/generator/models/include.rs
+++ b/cli/src/generator/models/include.rs
@@ -334,9 +334,9 @@ pub fn generate_macro(model: &dml::Model, module_path: &TokenStream) -> TokenStr
     quote! {
         #[macro_export]
         macro_rules! #macro_name {
-            ($(($($func_arg:ident: $func_arg_ty:ty),+) =>)? $module_name:ident { $(#selection_pattern_produce)+ }) => {
+            ($(($($func_arg:ident: $func_arg_ty:ty),+) =>)? $module_vis:vis $module_name:ident { $(#selection_pattern_produce)+ }) => {
                 #[allow(warnings)]
-                pub mod $module_name {
+                $module_vis mod $module_name {
                     $crate::#module_path::#model_name_snake::include!(@definitions; $(#selection_pattern_consume)+);
 
                     pub struct Include(Vec<::prisma_client_rust::Selection>);

--- a/cli/src/generator/models/select.rs
+++ b/cli/src/generator/models/select.rs
@@ -265,9 +265,9 @@ pub fn generate_macro(model: &dml::Model, module_path: &TokenStream) -> TokenStr
     quote! {
         #[macro_export]
         macro_rules! #macro_name {
-            ($(($($func_arg:ident: $func_arg_ty:ty),+) =>)? $module_vis:vis $module_name:ident { $(#selection_pattern_produce)+ }) => {
+            ($(($($func_arg:ident: $func_arg_ty:ty),+) =>)? $module_name:ident { $(#selection_pattern_produce)+ }) => {
                 #[allow(warnings)]
-                $module_vis mod $module_name {
+                pub mod $module_name {
                     $crate::#module_path::#model_name_snake::select!(@definitions; $(#selection_pattern_consume)+);
 
                     pub struct Select(Vec<::prisma_client_rust::Selection>);

--- a/cli/src/generator/models/select.rs
+++ b/cli/src/generator/models/select.rs
@@ -265,9 +265,9 @@ pub fn generate_macro(model: &dml::Model, module_path: &TokenStream) -> TokenStr
     quote! {
         #[macro_export]
         macro_rules! #macro_name {
-            ($(($($func_arg:ident: $func_arg_ty:ty),+) =>)? $module_name:ident { $(#selection_pattern_produce)+ }) => {
+            ($(($($func_arg:ident: $func_arg_ty:ty),+) =>)? $module_vis:vis $module_name:ident { $(#selection_pattern_produce)+ }) => {
                 #[allow(warnings)]
-                pub mod $module_name {
+                $module_vis mod $module_name {
                     $crate::#module_path::#model_name_snake::select!(@definitions; $(#selection_pattern_consume)+);
 
                     pub struct Select(Vec<::prisma_client_rust::Selection>);

--- a/docs/src/pages/extra/rspc.md
+++ b/docs/src/pages/extra/rspc.md
@@ -61,9 +61,9 @@ export type Operations = {
 };
 
 // rspc can export types that aren't even directly used in any operations!
-export interface Comment { id: string, content: string, postID: string, post: Post | null }
+export interface Comment { id: string, content: string, postID: string }
 
-export interface Post { id: string, title: string, comments: Array<Comment> | null }
+export interface Post { id: string, title: string }
 ```
 
 This also works for [select & include](/select-include):
@@ -100,6 +100,35 @@ export type Operations = {
     queries: { key: ["posts"], result: Array<{ id: string, title: string}> }
 };
 ```
+
+### Relation types
+
+It is important to note that the types generated for models do not have fields for relations.
+This is done to provide a better experience when using `include`,
+at the expense of a worse experience using `with`/`fetch` for fetching relations.
+
+This tradeoff was made as a result of our experience building [Spacedrive](https://spacedrive.com).
+Instead of all our TypeScript functions having to verify at runtime whether a relation had been loaded or not,
+as is the case when using `with/fetch`,
+each function has to explicitly specify the relations it wants loaded:
+
+```ts
+import { User, Post } from "./exported-types"
+
+// Only recieves scalar fields of User
+function needsOneUser(user: User) {}
+
+// Receives scalar fields + posts relation of User
+function needsOneUserWithPosts(user: User & { posts: Post[] }) {}
+```
+
+There are a few downsides to this approach:
+- It is necessary to know the name and type of the relation you are including in TypeScript
+  (though this is being worked on)
+- `with/fetch` can be modified dynamically
+- `with/fetch` provides better editor autocomplete
+
+However, we've found that these downsides are outweighed by the benefits of having full type-safety across your backend and frontend.
 
 ## Error Handling
 

--- a/docs/src/pages/getting-started/installation.md
+++ b/docs/src/pages/getting-started/installation.md
@@ -10,6 +10,8 @@ Prisma Client Rust's installation operates in a different way to most Rust proje
 
 `prisma-client-rust-cli` contains the Prisma generator and access to the Prisma CLI, but does not provide an executable binary - this must be created yourself.
 
+Prisma Client Rust requires a minimum Rust version of v1.62.0.
+
 ## Creating a CLI Binary
 
 ### Inside Your Crate
@@ -20,6 +22,12 @@ First, the main library and CLI package must be added to your project's Cargo.to
 [dependencies]
 prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.0" }
 prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.0" }
+```
+
+The generated client will need `serde`, so run `cargo add` to install it:
+
+```
+cargo add serde
 ```
 
 You'll also need to make sure you're using edition 2021 of Rust.

--- a/docs/src/pages/getting-started/setup.md
+++ b/docs/src/pages/getting-started/setup.md
@@ -18,8 +18,8 @@ prisma/
     migrations/
 ```
 
-Below is an example of a schema that exists in a `prisma` folder,
-uses a SQLite database and generates the client at `src/prisma.rs`:
+Below is an example of a schema located at `prisma/schema.prisma`.
+It uses a SQLite database and generates the client at `src/prisma.rs`:
 
 ```prisma
 datasource db {

--- a/docs/src/pages/getting-started/setup.md
+++ b/docs/src/pages/getting-started/setup.md
@@ -30,7 +30,7 @@ datasource db {
 generator client {
     // Corresponds to the cargo alias created earlier
     provider      = "cargo prisma"
-    // The location to generate the schema. Is relative to the position of the schema
+    // The location to generate the client. Is relative to the position of the schema
     output        = "../src/prisma.rs"
 }
 

--- a/docs/src/pages/getting-started/setup.md
+++ b/docs/src/pages/getting-started/setup.md
@@ -4,7 +4,22 @@ desc: Setup instructions
 layout: ../../layouts/MainLayout.astro
 ---
 
-If you have completed the [installation steps](installation) and setup the `cargo prisma <command>` alias, you are ready to add the Prisma Cliet Rust generator to your [Prisma schema](https://www.prisma.io/docs/concepts/components/prisma-schema). Below is an example of a schema that exists at the root of the project, uses a SQLite database and generates the client at `src/prisma.rs`:
+If you have completed the [installation steps](installation) and setup the `cargo prisma <command>` alias,
+you are ready to add the Prisma Client Rust generator to your [Prisma schema](https://www.prisma.io/docs/concepts/components/prisma-schema).
+
+A common file layout is as below, where the schema and migrations exist in their own folder:
+
+```
+Cargo.toml
+src/
+    main.rs
+prisma/
+    schema.prisma
+    migrations/
+```
+
+Below is an example of a schema that exists in a `prisma` folder,
+uses a SQLite database and generates the client at `src/prisma.rs`:
 
 ```prisma
 datasource db {
@@ -16,7 +31,7 @@ generator client {
     // Corresponds to the cargo alias created earlier
     provider      = "cargo prisma"
     // The location to generate the schema. Is relative to the position of the schema
-    output        = "./src/prisma.rs"
+    output        = "../src/prisma.rs"
 }
 
 model User {
@@ -25,13 +40,17 @@ model User {
 }
 ```
 
-Next, run `cargo prisma generate` to generate the client that will be used in your Rust code. If you have `rustfmt` installed, the generated code will be formatted for easier exploration and debugging.
+Next, run `cargo prisma generate` to generate the client that will be used in your Rust code.
+If you have `rustfmt` installed,
+the generated code will be formatted for easier exploration and debugging.
 
 ## Creating the Client
 
-First, make sure you are using the [Tokio](https://github.com/tokio-rs/tokio) async runtime. Other runtimes have not been tested, but since the [Prisma Engines](https://github.com/prisma/prisma-engines) use it there is likely no other option.
+First, make sure you are using the [Tokio](https://github.com/tokio-rs/tokio) async runtime.
+Other runtimes have not been tested, but since the [Prisma Engines](https://github.com/prisma/prisma-engines) use it there is likely no other option.
 
-Using the above schema for reference, this is how to create an instance of the Primsma client in a `main.rs` file right next to `prisma.rs`:
+Using the above schema for reference,
+this is how to create an instance of the Primsma client in a `main.rs` file right next to `prisma.rs`:
 
 ```rust
 mod prisma;
@@ -47,5 +66,7 @@ async fn main() {
 
 ## Naming Clashes
 
-Rust has a [reserved set of keywords](https://doc.rust-lang.org/reference/keywords.html) that cannot be used as names in your code. If you name a model or field something that after conversion to `snake_case` will be a restricted keyword, you will almost assuredly not be able to compile your project.
+Rust has a [reserved set of keywords](https://doc.rust-lang.org/reference/keywords.html) that cannot be used as names in your code.
+If you name a model or field something that after conversion to `snake_case` will be a restricted keyword,
+you will almost assuredly not be able to compile your project.
 While this is annoying, it is an unavoidable consequence of using Rust.

--- a/docs/src/pages/reading-data/select-include.md
+++ b/docs/src/pages/reading-data/select-include.md
@@ -202,7 +202,7 @@ async fn do_query() -> Vec<post_only_title::Data> {
 }
 
 // Generated type is equivalent to
-mod post_only_title {
+pub mod post_only_title {
     pub struct Data {
         title: String
     }
@@ -239,7 +239,7 @@ async fn do_query() -> Vec<post_only_title::Data> {
 }
 
 // Generated type is equivalent to
-mod post_with_comments {
+pub mod post_with_comments {
     pub struct Data {
         id: String,
         title: String,

--- a/examples/rspc/bindings.ts
+++ b/examples/rspc/bindings.ts
@@ -2,13 +2,14 @@
 
 export type Operations = {
     queries: 
+        { key: ["userNames"], result: Array<{ display_name: string }> } | 
         { key: ["usersWithPosts"], result: Array<{ id: string, display_name: string, posts: Array<{ id: string, content: string, user: { id: string, display_name: string } }> }> } | 
         { key: ["users"], result: Array<User> } | 
-        { key: ["userNames"], result: Array<{ display_name: string }> },
+        { key: ["posts"], result: Array<Post> },
     mutations: never,
     subscriptions: never
 };
 
-export interface Post { id: string, content: string, user: User | null, userId: string }
+export interface Post { id: string, content: string, userId: string }
 
-export interface User { id: string, displayName: string, posts: Array<Post> | null }
+export interface User { id: string, displayName: string }

--- a/examples/rspc/src/main.rs
+++ b/examples/rspc/src/main.rs
@@ -38,5 +38,8 @@ async fn main() {
                 .await
                 .map_err(Into::into)
         })
+        .query("posts", |db, _: ()| async move {
+            db.post().find_many(vec![]).exec().await.map_err(Into::into)
+        })
         .build();
 }


### PR DESCRIPTION
Changes how rspc types are generated, with relations not being included in model types, favouring use of `include` over `with`/`fetch`.