### PR TITLE
fix "Argument skipDuplicates Does Not Exist On Enclosing Type" in create_many

### DIFF
--- a/src/queries/create_many.rs
+++ b/src/queries/create_many.rs
@@ -12,6 +12,7 @@ where
     ctx: QueryContext<'a>,
     info: QueryInfo,
     pub set_params: Vec<Vec<Set>>,
+    #[cfg(not(any(feature = "mongodb", feature = "mssql")))]
     pub skip_duplicates: bool,
 }
 
@@ -24,10 +25,12 @@ where
             ctx,
             info,
             set_params,
+            #[cfg(not(any(feature = "mongodb", feature = "mssql")))]
             skip_duplicates: false,
         }
     }
 
+    #[cfg(not(any(feature = "mongodb", feature = "mssql")))]
     pub fn skip_duplicates(mut self) -> Self {
         self.skip_duplicates = true;
         self
@@ -36,7 +39,7 @@ where
     fn to_selection(
         model: &str,
         set_params: Vec<Vec<Set>>,
-        skip_duplicates: bool,
+        #[cfg(not(any(feature = "mongodb", feature = "mssql")))] skip_duplicates: bool,
     ) -> SelectionBuilder {
         let mut selection = Selection::builder(format!("createMany{}", model));
 
@@ -52,14 +55,19 @@ where
             ),
         );
 
+        #[cfg(not(any(feature = "mongodb", feature = "mssql")))]
         selection.push_argument("skipDuplicates", PrismaValue::Boolean(skip_duplicates));
 
         selection
     }
 
     pub(crate) fn exec_operation(self) -> (Operation, QueryContext<'a>) {
+        #[cfg(not(any(feature = "mongodb", feature = "mssql")))]
         let mut selection =
             Self::to_selection(self.info.model, self.set_params, self.skip_duplicates);
+
+        #[cfg(any(feature = "mongodb", feature = "mssql"))]
+        let mut selection = Self::to_selection(self.info.model, self.set_params);
 
         selection.push_nested_selection(BatchResult::selection());
 

--- a/src/queries/create_many.rs
+++ b/src/queries/create_many.rs
@@ -12,7 +12,6 @@ where
     ctx: QueryContext<'a>,
     info: QueryInfo,
     pub set_params: Vec<Vec<Set>>,
-    #[cfg(not(any(feature = "mongodb", feature = "mssql")))]
     pub skip_duplicates: bool,
 }
 
@@ -25,7 +24,6 @@ where
             ctx,
             info,
             set_params,
-            #[cfg(not(any(feature = "mongodb", feature = "mssql")))]
             skip_duplicates: false,
         }
     }
@@ -39,7 +37,7 @@ where
     fn to_selection(
         model: &str,
         set_params: Vec<Vec<Set>>,
-        #[cfg(not(any(feature = "mongodb", feature = "mssql")))] skip_duplicates: bool,
+        skip_duplicates: bool,
     ) -> SelectionBuilder {
         let mut selection = Selection::builder(format!("createMany{}", model));
 
@@ -62,12 +60,8 @@ where
     }
 
     pub(crate) fn exec_operation(self) -> (Operation, QueryContext<'a>) {
-        #[cfg(not(any(feature = "mongodb", feature = "mssql")))]
         let mut selection =
             Self::to_selection(self.info.model, self.set_params, self.skip_duplicates);
-
-        #[cfg(any(feature = "mongodb", feature = "mssql"))]
-        let mut selection = Self::to_selection(self.info.model, self.set_params);
 
         selection.push_nested_selection(BatchResult::selection());
 


### PR DESCRIPTION
According to the hard-coded capabilities, the following two DB do not support skip_duplicates:
- mssql
- MongoDB

Therefore, remove skip_duplicates field whenever one of these two features is enabled.