### PR TITLE
merge and operator fields

### DIFF
--- a/cli/src/generator/models/mod.rs
+++ b/cli/src/generator/models/mod.rs
@@ -357,11 +357,13 @@ pub fn generate(args: &GenerateArgs, module_path: TokenStream) -> Vec<TokenStrea
                 },
                 false => quote! {
                     #pcr::SerializedWhereValue::Object(
-                        value
-                            .into_iter()
-                            .map(Into::<#pcr::SerializedWhere>::into)
-                            .map(Into::into)
-                            .collect()
+                        ::prisma_client_rust::merge_fields(
+                            value
+                                .into_iter()
+                                .map(Into::<#pcr::SerializedWhere>::into)
+                                .map(Into::into)
+                                .collect()
+                        )
                     )
                 },
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,12 +110,14 @@ macro_rules! or {
     };
 }
 
+pub type ObjectFields = Vec<(String, PrismaValue)>;
+
 /// Creates a PrismaValue::Object from a list of key-value pairs.
 /// If a key has multiple values that are PrismaValue::Objects, they will be merged.
-pub fn merged_object(elements: Vec<(String, PrismaValue)>) -> PrismaValue {
+pub fn merge_fields(fields: ObjectFields) -> ObjectFields {
     let mut merged = HashMap::new();
 
-    for el in elements {
+    for el in fields {
         match (merged.get_mut(&el.0), el.1) {
             (Some(PrismaValue::Object(existing)), PrismaValue::Object(incoming)) => {
                 existing.extend(incoming);
@@ -129,5 +131,5 @@ pub fn merged_object(elements: Vec<(String, PrismaValue)>) -> PrismaValue {
         }
     }
 
-    PrismaValue::Object(merged.into_iter().collect())
+    merged.into_iter().collect()
 }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -15,4 +15,3 @@ pub fn and<T: From<Operator<T>>>(params: Vec<T>) -> T {
 pub fn or<T: From<Operator<T>>>(params: Vec<T>) -> T {
     Operator::Or(params).into()
 }
-

--- a/src/queries/count.rs
+++ b/src/queries/count.rs
@@ -2,7 +2,7 @@ use prisma_models::PrismaValue;
 use query_core::{Operation, Selection};
 use serde::Deserialize;
 
-use crate::{merged_object, BatchQuery, SerializedWhere};
+use crate::{merge_fields, BatchQuery, SerializedWhere};
 
 use super::{QueryContext, QueryInfo};
 
@@ -62,13 +62,13 @@ where
         if self.where_params.len() > 0 {
             selection.push_argument(
                 "where",
-                merged_object(
+                PrismaValue::Object(merge_fields(
                     self.where_params
                         .into_iter()
                         .map(Into::<SerializedWhere>::into)
                         .map(|s| (s.field, s.value.into()))
                         .collect(),
-                ),
+                )),
             );
         }
 

--- a/src/queries/create.rs
+++ b/src/queries/create.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     include::{Include, IncludeType},
-    merged_object,
+    merge_fields,
     select::{Select, SelectType},
     BatchQuery,
 };
@@ -54,7 +54,9 @@ where
 
         selection.push_argument(
             "data",
-            merged_object(set_params.into_iter().map(Into::into).collect()),
+            PrismaValue::Object(merge_fields(
+                set_params.into_iter().map(Into::into).collect(),
+            )),
         );
 
         selection

--- a/src/queries/create_many.rs
+++ b/src/queries/create_many.rs
@@ -1,7 +1,7 @@
 use prisma_models::PrismaValue;
 use query_core::{Operation, Selection, SelectionBuilder};
 
-use crate::{merged_object, BatchQuery, BatchResult};
+use crate::{merge_fields, BatchQuery, BatchResult};
 
 use super::{QueryContext, QueryInfo};
 
@@ -48,7 +48,11 @@ where
             PrismaValue::List(
                 set_params
                     .into_iter()
-                    .map(|fields| merged_object(fields.into_iter().map(Into::into).collect()))
+                    .map(|fields| {
+                        PrismaValue::Object(merge_fields(
+                            fields.into_iter().map(Into::into).collect(),
+                        ))
+                    })
                     .collect(),
             ),
         );

--- a/src/queries/delete_many.rs
+++ b/src/queries/delete_many.rs
@@ -1,6 +1,7 @@
+use prisma_models::PrismaValue;
 use query_core::{Operation, Selection};
 
-use crate::{merged_object, BatchQuery, BatchResult};
+use crate::{merge_fields, BatchQuery, BatchResult};
 
 use super::{QueryContext, QueryInfo, SerializedWhere};
 
@@ -33,13 +34,13 @@ where
         if self.where_params.len() > 0 {
             selection.push_argument(
                 "where",
-                merged_object(
+                PrismaValue::Object(merge_fields(
                     self.where_params
                         .into_iter()
                         .map(Into::<SerializedWhere>::into)
                         .map(|s| (s.field, s.value.into()))
                         .collect(),
-                ),
+                )),
             );
         }
 

--- a/src/queries/find_first.rs
+++ b/src/queries/find_first.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     include::{Include, IncludeType},
-    merged_object,
+    merge_fields,
     select::{Select, SelectType},
     BatchQuery,
 };
@@ -94,13 +94,13 @@ where
         if where_params.len() > 0 {
             selection.push_argument(
                 "where",
-                merged_object(
+                PrismaValue::Object(merge_fields(
                     where_params
                         .into_iter()
                         .map(Into::<SerializedWhere>::into)
                         .map(|s| (s.field, s.value.into()))
                         .collect(),
-                ),
+                )),
             );
         }
 

--- a/src/queries/find_many.rs
+++ b/src/queries/find_many.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     include::{Include, IncludeType},
-    merged_object,
+    merge_fields,
     select::{Select, SelectType},
     BatchQuery,
 };
@@ -97,13 +97,13 @@ where
         if where_params.len() > 0 {
             selection.push_argument(
                 "where",
-                merged_object(
+                PrismaValue::Object(merge_fields(
                     where_params
                         .into_iter()
                         .map(Into::<SerializedWhere>::into)
                         .map(|s| (s.field, s.value.into()))
                         .collect(),
-                ),
+                )),
             );
         }
 

--- a/src/queries/update.rs
+++ b/src/queries/update.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     include::{Include, IncludeType},
-    merged_object,
+    merge_fields,
     select::{Select, SelectType},
     BatchQuery,
 };
@@ -69,7 +69,9 @@ where
 
         selection.push_argument(
             "data",
-            merged_object(set_params.into_iter().map(Into::into).collect()),
+            PrismaValue::Object(merge_fields(
+                set_params.into_iter().map(Into::into).collect(),
+            )),
         );
 
         selection

--- a/src/queries/update_many.rs
+++ b/src/queries/update_many.rs
@@ -1,7 +1,7 @@
 use prisma_models::PrismaValue;
 use query_core::{Operation, Selection};
 
-use crate::{merged_object, BatchQuery, BatchResult};
+use crate::{merge_fields, BatchQuery, BatchResult};
 
 use super::{QueryContext, QueryInfo, SerializedWhere};
 
@@ -41,19 +41,21 @@ where
 
         selection.push_argument(
             "data",
-            merged_object(self.set_params.into_iter().map(Into::into).collect()),
+            PrismaValue::Object(merge_fields(
+                self.set_params.into_iter().map(Into::into).collect(),
+            )),
         );
 
         if self.where_params.len() > 0 {
             selection.push_argument(
                 "where",
-                merged_object(
+                PrismaValue::Object(merge_fields(
                     self.where_params
                         .into_iter()
                         .map(Into::<SerializedWhere>::into)
                         .map(|s| (s.field, s.value.into()))
                         .collect(),
-                ),
+                )),
             );
         }
 


### PR DESCRIPTION
Wraps fields of the `and` operator in `merge_fields` in the same way as regular objects.

Closes #175 