### PR TITLE
fix(cli): custom schema is not being be passed

### DIFF
--- a/cli/src/generator/header.rs
+++ b/cli/src/generator/header.rs
@@ -13,6 +13,16 @@ fn find_schema_path() -> Result<PathBuf, ()> {
 
     let root_file_path = current_dir.join(SCHEMA_PRISMA);
     let nested_file_path = current_dir.join("prisma").join(SCHEMA_PRISMA);
+    let custom_file_path =
+        std::env::var("PRISMA_CUSOTM_SCHEMA_PATH").map(|custom| current_dir.join(custom));
+
+    if let Ok(custom_path) = custom_file_path {
+        if custom_path.exists() {
+            return Ok(custom_path);
+        } else {
+            return Err(());
+        }
+    }
 
     match root_file_path.exists() {
         true => Ok(root_file_path),

--- a/sdk/src/prisma_cli.rs
+++ b/sdk/src/prisma_cli.rs
@@ -4,11 +4,8 @@ use std::process::Command;
 
 pub fn main(args: &Vec<String>) {
     let dir = binaries::global_cache_dir();
-
     binaries::fetch_native(&dir).unwrap();
-
     let prisma = binaries::prisma_cli_name();
-
     let mut cmd = Command::new(dir.join(prisma));
     let binary_name =
         platform::check_for_extension(&platform::name(), &platform::binary_platform_name());
@@ -18,6 +15,11 @@ pub fn main(args: &Vec<String>) {
     cmd.envs(env::vars());
     cmd.env("PRISMA_HIDE_UPDATE_MESSAGE", "true");
     cmd.env("PRISMA_CLI_QUERY_ENGINE_TYPE", "binary");
+    // TODO: This can't be merged. Find a better way to extract it
+    cmd.env(
+        "PRISMA_CUSOTM_SCHEMA_PATH",
+        args.last().unwrap().replace("--schema=", ""),
+    );
 
     for e in ENGINES {
         match env::var(e.env) {

--- a/sdk/src/prisma_cli.rs
+++ b/sdk/src/prisma_cli.rs
@@ -15,11 +15,11 @@ pub fn main(args: &Vec<String>) {
     cmd.envs(env::vars());
     cmd.env("PRISMA_HIDE_UPDATE_MESSAGE", "true");
     cmd.env("PRISMA_CLI_QUERY_ENGINE_TYPE", "binary");
-    // TODO: This can't be merged. Find a better way to extract it
-    cmd.env(
-        "PRISMA_CUSOTM_SCHEMA_PATH",
-        args.last().unwrap().replace("--schema=", ""),
-    );
+    // TODO: Do we need to support --schema, "path" in addtion to --schema=""?
+    args.iter()
+        .find(|arg| arg.contains("--schema="))
+        .map(|arg| arg.replace("--schema=", ""))
+        .map(|path| cmd.env("PRISMA_CUSOTM_SCHEMA_PATH", path));
 
     for e in ENGINES {
         match env::var(e.env) {


### PR DESCRIPTION
This is a quick workaround for an existing bug that doesn't pass cli arguments down.

I couldn't figure out what the bug is, or where I can figure debug it. The abstraction is a bit heavy for me. I'm sure there is a step where the args are processed and --schema is dropped.

To reproduce the bug, try to have the prisma_cli main function be called in bin in a project instead of a workspace. e.g.

root/Cargo.toml
```toml
[workspace]
default-members = ["api"]
members = [ "api" ]
resolver = "2"
```

root/api/Cargo.toml
```toml
[features]
default = []
prisma-generate = [ "prisma-client-rust-cli" ]

[dependencies.prisma-client-rust-cli]
workspace = true
optional = true
features = [ "migrations" ]
```

Then it root,

```bash
cargo run -p api --bin prisma --features prisma-generate -- generate --schema=./api/schema.prisma 
```

cc @Brendonovich