### PR TITLE
Improve error message when `openssl version -v` fails

### DIFF
--- a/sdk/src/binaries/platform.rs
+++ b/sdk/src/binaries/platform.rs
@@ -113,7 +113,7 @@ fn get_openssl() -> String {
         .arg("version")
         .arg("-v")
         .output()
-        .unwrap();
+        .expect("Unable to run determine openssl version; is the openssl binary installed?");
 
     let stdout = String::from_utf8(out.stdout).unwrap();
     let stderr = String::from_utf8(out.stderr).unwrap();


### PR DESCRIPTION
On a fresh Fedora Workstation 37 install, the `openssl` binary is not installed. This lead to an unhelpful error message when trying to run `cargo prisma`:

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value:
    Os { code: 2, kind: NotFound, message: "No such file or directory" }',
       /home/aiden/.cargo/git/checkouts/prisma-client-rust-fa967aa5ad0ec391/e12e693/sdk/src/binaries/platform.rs:116:10
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

The backtrace eventually lead me to the source to determine the issue.