### PR TITLE
derive clone for generated client

### DIFF
--- a/cli/src/generator/client.rs
+++ b/cli/src/generator/client.rs
@@ -95,6 +95,7 @@ pub fn generate(args: &GenerateArgs) -> TokenStream {
             }
         }
 
+        #[derive(Clone)]
         pub struct PrismaClient(#pcr::PrismaClientInternals);
 
         impl ::std::fmt::Debug for PrismaClient {


### PR DESCRIPTION
Derives `Clone` for the generated `PrismaClient`. `PrismaClient`s only field implements `Clone` so this seems pretty uncontroversial.

Rationale is to share access to the database with different parts of the program without wrapping in `Arc`.