### PR TITLE
Update axum-rest example 

### DIFF
--- a/examples/axum-rest/Cargo.toml
+++ b/examples/axum-rest/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "axum-rest-example"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-prisma-client-rust = { path = "../..", default-features = false, features = ["migrations", "sqlite"] }
+prisma-client-rust = { path = "../..", default-features = false, features = ["migrations", "sqlite", "mocking"] }
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
-axum = "0.5"
+axum = "0.6"

--- a/examples/axum-rest/src/main.rs
+++ b/examples/axum-rest/src/main.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use crate::db::*;
 
-pub mod db;
-pub mod routes;
+mod db;
+mod routes;
 
 #[tokio::main]
 async fn main() {
@@ -17,9 +17,9 @@ async fn main() {
         .nest("/api", routes::create_route())
         .layer(Extension(prisma_client));
 
-    println!("Example Prisma x Axum running on http://localhost:5000/api");
+    println!("Example Prisma x Axum running on http://127.0.0.1:5000");
 
-    axum::Server::bind(&"0.0.0.0:5000".parse().unwrap())
+    axum::Server::bind(&"127.0.0.1:5000".parse().unwrap())
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/axum-rest/src/routes.rs
+++ b/examples/axum-rest/src/routes.rs
@@ -9,12 +9,13 @@ use prisma_client_rust::{
     prisma_errors::query_engine::{RecordNotFound, UniqueKeyViolation},
     QueryError,
 };
+use std::sync::Arc;
 
 use serde::Deserialize;
 
-use crate::db::{self, comments, user};
+use crate::db::*;
 
-type Database = Extension<std::sync::Arc<db::PrismaClient>>;
+type Database = Extension<Arc<PrismaClient>>;
 type AppResult<T> = Result<T, AppError>;
 type AppJsonResult<T> = AppResult<Json<T>>;
 
@@ -35,7 +36,7 @@ struct CommentRequest {
 
 /api/user => GET, POST
 /api/user/:username => PUT, DELETE
-/comment => POST
+/api/comment => POST
 
 */
 pub fn create_route() -> Router {
@@ -48,7 +49,7 @@ pub fn create_route() -> Router {
         .route("/comment", post(handle_comment_post))
 }
 
-async fn handle_user_get(db: Database) -> AppResult<Json<Vec<user::Data>>> {
+async fn handle_user_get(db: Database) -> AppJsonResult<Vec<user::Data>> {
     let users = db
         .user()
         .find_many(vec![])
@@ -128,7 +129,7 @@ impl From<QueryError> for AppError {
     }
 }
 
-// This centralizes all differents errors from our app in one place
+// This centralizes all different errors from our app in one place
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let status = match self {


### PR DESCRIPTION
The `axum-rest` example couldn't be run with `cargo run`, so I enabled the `mocking` feature to fix it. 
I also fixed some comments and made the imports consistent.