### PR TITLE
Handling prisma not having a OpenSSL bundle for version 3.1.x

### DIFF
--- a/crates/cli/src/binaries/platform.rs
+++ b/crates/cli/src/binaries/platform.rs
@@ -126,7 +126,10 @@ fn parse_openssl_version(v: &str) -> String {
     let r = Regex::new(r"^OpenSSL\s(\d+\.\d+)\.\d");
     let matches = r.unwrap().captures(v).unwrap();
     if matches.len() > 0 {
-        matches.get(1).unwrap().as_str().to_string() + ".x"
+        match matches.get(1).unwrap().as_str() {
+            "3.1" => "3.0.x".to_string(),
+            version => format!("{version}.x"),
+        }
     } else {
         "1.1.x".to_string()
     }


### PR DESCRIPTION
Found out that due to Arch Linux updating to OpenSSL 3.1.*, it broke `pnpm prep` at Spacedrive, it was trying to fetch a version that doesn't exist of bundled OpenSSL from the Prisma team. Now using 3.0.x version as it is API compatible.