### PR TITLE
Fix minor typo in error handling docs page

### DIFF
--- a/docs/pages/extra/error-handling.md
+++ b/docs/pages/extra/error-handling.md
@@ -8,7 +8,7 @@ Query errors resemble the following:
 pub enum Error {
     Execute(user_facing_errors::Error),
     Serialize(serde_json::Error),
-    Deseiralize(serde_json::Error)
+    Deserialize(serde_json::Error)
 }
 ```
 


### PR DESCRIPTION
Fixed a minor typo in a code snippet at https://prisma.brendonovich.dev/extra/error-handling.