### PR TITLE
Restrict compound uniques to unique params

### DIFF
--- a/crates/generator/src/models/actions.rs
+++ b/crates/generator/src/models/actions.rs
@@ -104,7 +104,7 @@ pub fn upsert_fn(model: ModelWalker) -> Option<TokenStream> {
         ) -> UpsertQuery<'a> {
             UpsertQuery::new(
                 self.client,
-                _where.into(),
+                _where,
                 _create.to_params(),
                 _update
             )
@@ -150,7 +150,7 @@ pub fn struct_definition(model: ModelWalker, args: &GenerateArgs) -> TokenStream
             pub fn find_unique(self, _where: UniqueWhereParam) -> FindUniqueQuery<'a> {
                 FindUniqueQuery::new(
                     self.client,
-                    _where.into()
+                    _where
                 )
             }
 
@@ -176,7 +176,7 @@ pub fn struct_definition(model: ModelWalker, args: &GenerateArgs) -> TokenStream
             pub fn update(self, _where: UniqueWhereParam, _params: Vec<SetParam>) -> UpdateQuery<'a> {
                 UpdateQuery::new(
                     self.client,
-                    _where.into(),
+                    _where,
                     _params,
                     vec![]
                 )
@@ -185,7 +185,7 @@ pub fn struct_definition(model: ModelWalker, args: &GenerateArgs) -> TokenStream
             pub fn update_unchecked(self, _where: UniqueWhereParam, _params: Vec<UncheckedSetParam>) -> UpdateUncheckedQuery<'a> {
                 UpdateUncheckedQuery::new(
                     self.client,
-                    _where.into(),
+                    _where,
                     _params.into_iter().map(Into::into).collect(),
                     vec![]
                 )
@@ -204,7 +204,7 @@ pub fn struct_definition(model: ModelWalker, args: &GenerateArgs) -> TokenStream
             pub fn delete(self, _where: UniqueWhereParam) -> DeleteQuery<'a> {
                 DeleteQuery::new(
                     self.client,
-                    _where.into(),
+                    _where,
                     vec![]
                 )
             }

--- a/crates/generator/src/models/set_params.rs
+++ b/crates/generator/src/models/set_params.rs
@@ -460,7 +460,6 @@ fn field_set_params(
                                             #pcr::PrismaValue::List(
                                                 where_params
                                                     .into_iter()
-                                                    .map(Into::<super::#relation_model_name_snake::WhereParam>::into)
                                                     .map(#pcr::WhereInput::serialize)
                                                     .map(#pcr::SerializedWhereInput::transform_equals)
                                                     .map(|v| #pcr::PrismaValue::Object(vec![v]))
@@ -483,7 +482,6 @@ fn field_set_params(
                                             #pcr::PrismaValue::Object(
                                                 [where_param]
                                                     .into_iter()
-                                                    .map(Into::<super::#relation_model_name_snake::WhereParam>::into)
                                                     .map(#pcr::WhereInput::serialize)
                                                     .map(#pcr::SerializedWhereInput::transform_equals)
                                                     .collect()

--- a/crates/generator/src/models/types.rs
+++ b/crates/generator/src/models/types.rs
@@ -46,6 +46,7 @@ pub fn r#struct(model: ModelWalker, module_path: &TokenStream) -> TokenStream {
         impl #pcr::ModelTypes for Types {
             type Data = Data;
             type Where = WhereParam;
+            type WhereUnique = UniqueWhereParam;
             type UncheckedSet = UncheckedSetParam;
             type Set = SetParam;
             type With = WithParam;

--- a/crates/lib/src/queries/count.rs
+++ b/crates/lib/src/queries/count.rs
@@ -109,9 +109,8 @@ impl<'a, Actions: ModelTypes> Query<'a> for Count<'a, Actions> {
                             PrismaValue::Object(
                                 self.cursor_params
                                     .into_iter()
-                                    .map(Into::into)
                                     .map(WhereInput::serialize)
-                                    .map(SerializedWhereInput::transform_equals)
+                                    .map(|s| (s.field, s.value.into()))
                                     .collect(),
                             )
                             .into(),

--- a/crates/lib/src/queries/delete.rs
+++ b/crates/lib/src/queries/delete.rs
@@ -8,14 +8,14 @@ use crate::{
 
 pub struct Delete<'a, Actions: ModelTypes> {
     client: &'a PrismaClientInternals,
-    pub where_param: Actions::Where,
+    pub where_param: Actions::WhereUnique,
     pub with_params: Vec<Actions::With>,
 }
 
 impl<'a, Actions: ModelTypes> Delete<'a, Actions> {
     pub fn new(
         client: &'a PrismaClientInternals,
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         with_params: Vec<Actions::With>,
     ) -> Self {
         Self {
@@ -31,7 +31,7 @@ impl<'a, Actions: ModelTypes> Delete<'a, Actions> {
     }
 
     fn to_selection(
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         nested_selections: impl IntoIterator<Item = Selection>,
     ) -> Selection {
         Self::base_selection(

--- a/crates/lib/src/queries/find_first.rs
+++ b/crates/lib/src/queries/find_first.rs
@@ -7,8 +7,6 @@ use crate::{
     WhereInput, WhereQuery, WithQuery,
 };
 
-use super::SerializedWhereInput;
-
 pub struct FindFirst<'a, Actions: ModelTypes> {
     client: &'a PrismaClientInternals,
     pub where_params: Vec<Actions::Where>,
@@ -98,9 +96,8 @@ impl<'a, Actions: ModelTypes> FindFirst<'a, Actions> {
                         PrismaValue::Object(
                             cursor_params
                                 .into_iter()
-                                .map(Into::into)
                                 .map(WhereInput::serialize)
-                                .map(SerializedWhereInput::transform_equals)
+                                .map(|s| (s.field, s.value.into()))
                                 .collect(),
                         )
                         .into(),

--- a/crates/lib/src/queries/find_many.rs
+++ b/crates/lib/src/queries/find_many.rs
@@ -98,9 +98,8 @@ impl<'a, Actions: ModelTypes> FindMany<'a, Actions> {
                         PrismaValue::Object(
                             cursor_params
                                 .into_iter()
-                                .map(Into::into)
                                 .map(WhereInput::serialize)
-                                .map(SerializedWhereInput::transform_equals)
+                                .map(|s| (s.field, s.value.into()))
                                 .collect(),
                         )
                         .into(),
@@ -301,9 +300,8 @@ impl<Actions: ModelTypes> ManyArgs<Actions> {
                     PrismaValue::Object(
                         self.cursor_params
                             .into_iter()
-                            .map(Into::into)
                             .map(WhereInput::serialize)
-                            .map(SerializedWhereInput::transform_equals)
+                            .map(|s| (s.field, s.value.into()))
                             .collect(),
                     )
                     .into(),

--- a/crates/lib/src/queries/find_unique.rs
+++ b/crates/lib/src/queries/find_unique.rs
@@ -10,13 +10,13 @@ use crate::{
 
 pub struct FindUnique<'a, Actions: ModelTypes> {
     client: &'a PrismaClientInternals,
-    pub where_param: Actions::Where,
+    pub where_param: Actions::WhereUnique,
     pub with_params: Vec<Actions::With>,
     _data: PhantomData<(Actions::Set, Actions::Data)>,
 }
 
 impl<'a, Actions: ModelTypes> FindUnique<'a, Actions> {
-    pub fn new(client: &'a PrismaClientInternals, where_param: Actions::Where) -> Self {
+    pub fn new(client: &'a PrismaClientInternals, where_param: Actions::WhereUnique) -> Self {
         Self {
             client,
             where_param,
@@ -31,7 +31,7 @@ impl<'a, Actions: ModelTypes> FindUnique<'a, Actions> {
     }
 
     fn to_selection(
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         nested_selections: impl IntoIterator<Item = Selection>,
     ) -> Selection {
         Self::base_selection(

--- a/crates/lib/src/queries/query.rs
+++ b/crates/lib/src/queries/query.rs
@@ -20,11 +20,12 @@ pub trait Query<'a>: QueryConvert {
 pub trait ModelTypes {
     type Data: Data;
     type Where: WhereInput;
+    type WhereUnique: WhereInput;
     type UncheckedSet: Into<(String, PrismaValue)>;
     type Set: Into<(String, PrismaValue)>;
     type With: Into<Selection>;
     type OrderBy: Into<(String, PrismaValue)>;
-    type Cursor: Into<Self::Where>;
+    type Cursor: WhereInput;
 
     const MODEL: &'static str;
 

--- a/crates/lib/src/queries/update.rs
+++ b/crates/lib/src/queries/update.rs
@@ -9,7 +9,7 @@ use crate::{
 
 pub struct Update<'a, Actions: ModelTypes> {
     client: &'a PrismaClientInternals,
-    pub where_param: Actions::Where,
+    pub where_param: Actions::WhereUnique,
     pub set_params: Vec<Actions::Set>,
     pub with_params: Vec<Actions::With>,
 }
@@ -17,7 +17,7 @@ pub struct Update<'a, Actions: ModelTypes> {
 impl<'a, Actions: ModelTypes> Update<'a, Actions> {
     pub fn new(
         client: &'a PrismaClientInternals,
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         set_params: Vec<Actions::Set>,
         with_params: Vec<Actions::With>,
     ) -> Self {
@@ -35,7 +35,7 @@ impl<'a, Actions: ModelTypes> Update<'a, Actions> {
     }
 
     fn to_selection(
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         set_params: Vec<Actions::Set>,
         nested_selections: impl IntoIterator<Item = Selection>,
     ) -> Selection {

--- a/crates/lib/src/queries/update_unchecked.rs
+++ b/crates/lib/src/queries/update_unchecked.rs
@@ -9,7 +9,7 @@ use crate::{
 
 pub struct UpdateUnchecked<'a, Actions: ModelTypes> {
     client: &'a PrismaClientInternals,
-    pub where_param: Actions::Where,
+    pub where_param: Actions::WhereUnique,
     pub set_params: Vec<Actions::UncheckedSet>,
     pub with_params: Vec<Actions::With>,
 }
@@ -17,7 +17,7 @@ pub struct UpdateUnchecked<'a, Actions: ModelTypes> {
 impl<'a, Actions: ModelTypes> UpdateUnchecked<'a, Actions> {
     pub fn new(
         client: &'a PrismaClientInternals,
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         set_params: Vec<Actions::UncheckedSet>,
         with_params: Vec<Actions::With>,
     ) -> Self {
@@ -35,7 +35,7 @@ impl<'a, Actions: ModelTypes> UpdateUnchecked<'a, Actions> {
     }
 
     fn to_selection(
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         set_params: Vec<Actions::UncheckedSet>,
         nested_selections: impl IntoIterator<Item = Selection>,
     ) -> Selection {

--- a/crates/lib/src/queries/upsert.rs
+++ b/crates/lib/src/queries/upsert.rs
@@ -8,7 +8,7 @@ use crate::{
 
 pub struct Upsert<'a, Actions: ModelTypes> {
     client: &'a PrismaClientInternals,
-    pub where_param: Actions::Where,
+    pub where_param: Actions::WhereUnique,
     pub create_params: Vec<Actions::Set>,
     pub update_params: Vec<Actions::Set>,
     pub with_params: Vec<Actions::With>,
@@ -17,7 +17,7 @@ pub struct Upsert<'a, Actions: ModelTypes> {
 impl<'a, Actions: ModelTypes> Upsert<'a, Actions> {
     pub fn new(
         client: &'a PrismaClientInternals,
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         create_params: Vec<Actions::Set>,
         update_params: Vec<Actions::Set>,
     ) -> Self {
@@ -36,7 +36,7 @@ impl<'a, Actions: ModelTypes> Upsert<'a, Actions> {
     }
 
     fn to_selection(
-        where_param: Actions::Where,
+        where_param: Actions::WhereUnique,
         create_params: Vec<Actions::Set>,
         update_params: Vec<Actions::Set>,
         nested_selections: impl IntoIterator<Item = Selection>,


### PR DESCRIPTION
Compound unique fields are being included in `WhereParam` which isn't good since they should actually only be available in `UniqueWhereParam`.