### PR TITLE
Update migrations error message

### DIFF
--- a/crates/generator/src/header.rs
+++ b/crates/generator/src/header.rs
@@ -9,7 +9,7 @@ fn find_migrations_path(schema_path: &PathBuf) -> PathBuf {
         .parent()
         .map(|p| p.join("migrations"))
         .filter(|p| p.exists())
-        .expect("Migrations folder not found!")
+        .expect("Migrations folder not found! Please create one in the same directory as your schema.prisma file.")
 }
 
 pub fn generate(args: &GenerateArgs) -> TokenStream {

--- a/crates/generator/src/header.rs
+++ b/crates/generator/src/header.rs
@@ -9,7 +9,7 @@ fn find_migrations_path(schema_path: &PathBuf) -> PathBuf {
         .parent()
         .map(|p| p.join("migrations"))
         .filter(|p| p.exists())
-        .expect("Migrations folder not found! Please create one in the same directory as your schema.prisma file.")
+        .expect("Migrations folder not found! Please create one in the same folder as your schema.prisma file.")
 }
 
 pub fn generate(args: &GenerateArgs) -> TokenStream {


### PR DESCRIPTION
Make the missing migrations dir error message more helpful.

I was originally going to change the function to actually create the missing folder (can still do this if you want).