### PR TITLE
Feature: Allow skipping downloads of engines by setting env vars

### DIFF
--- a/crates/cli/src/binaries/mod.rs
+++ b/crates/cli/src/binaries/mod.rs
@@ -48,20 +48,6 @@ pub fn global_cache_dir() -> PathBuf {
         .join(PRISMA_CLI_VERSION)
 }
 
-pub fn fetch_native(to_dir: &PathBuf) -> Result<(), String> {
-    if !to_dir.is_absolute() {
-        Err("to_dir must be absolute".to_string())?;
-    }
-
-    download_cli(to_dir)?;
-
-    for e in &ENGINES {
-        download_engine(&e.name, &to_dir)?;
-    }
-
-    Ok(())
-}
-
 pub fn download_cli(to_dir: &PathBuf) -> Result<(), String> {
     let cli = prisma_cli_name();
 
@@ -92,7 +78,7 @@ pub fn download_cli(to_dir: &PathBuf) -> Result<(), String> {
     Ok(())
 }
 
-fn download_engine(engine_name: &str, to_dir: &PathBuf) -> Result<(), String> {
+pub fn download_engine(engine_name: &str, to_dir: &PathBuf) -> Result<(), String> {
     let os_name = platform::binary_platform_name();
 
     let to = platform::check_for_extension(

--- a/crates/cli/src/prisma_cli.rs
+++ b/crates/cli/src/prisma_cli.rs
@@ -5,13 +5,12 @@ use std::process::Command;
 pub fn main(args: &Vec<String>) {
     let dir = binaries::global_cache_dir();
 
-    binaries::fetch_native(&dir).unwrap();
-
+    binaries::download_cli(&dir).unwrap();
     let prisma = binaries::prisma_cli_name();
-
-    let mut cmd = Command::new(dir.join(prisma));
     let binary_name =
         platform::check_for_extension(&platform::name(), &platform::binary_platform_name());
+
+    let mut cmd = Command::new(dir.join(prisma));
 
     cmd.args(args);
 
@@ -25,6 +24,7 @@ pub fn main(args: &Vec<String>) {
                 cmd.env(e.env, path);
             }
             Err(_) => {
+                binaries::download_engine(&e.name, &dir).unwrap();
                 let path = dir
                     .join(binaries::ENGINE_VERSION)
                     .join(format!("prisma-{}-{}", e.name, binary_name));

--- a/integration-tests/tests/lib.rs
+++ b/integration-tests/tests/lib.rs
@@ -8,7 +8,7 @@ mod utils;
 
 #[tokio::test]
 async fn aaaa_run_migrations() -> TestResult {
-    let client = db::new_client().await.unwrap();
+    let client = db::PrismaClient::_builder().build().await.unwrap();
 
     client._db_push().accept_data_loss().await.unwrap();
 


### PR DESCRIPTION
Closes #395

It adds support for operating systems that Prisma does not compile binaries for like NixOS by setting the needed env variables for the engines.

It should still support the previous way of working but it's worth noting that I haven't tested that yet.
I currently only have a NixOS machine so I haven't been able to test it on something like Darwin.