### PR TITLE
Replace dotenv with dotenvy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-axum",
  "axum 0.5.17",
- "dotenv",
+ "dotenvy",
  "prisma-client-rust",
  "serde",
  "tokio",
@@ -1742,10 +1742,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -4771,7 +4771,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "diagnostics",
- "dotenv",
+ "dotenvy",
  "futures",
  "include_dir",
  "indexmap",

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -60,4 +60,4 @@ specta = { optional = true, workspace = true, features = [
 
 # features = "rspc"
 rspc = { optional = true, workspace = true }
-dotenv = "0.15.0"
+dotenvy = "0.15.7"

--- a/crates/lib/src/client.rs
+++ b/crates/lib/src/client.rs
@@ -170,7 +170,7 @@ impl PrismaClientInternals {
         let url = match url {
             Some(url) => url,
             None => {
-                let url = match source.load_url(|key| dotenv::var(key).ok()) {
+                let url = match source.load_url(|key| dotenvy::var(key).ok()) {
                     Ok(url) => Some(url),
                     Err(_) => source.load_shadow_database_url()?,
                 }

--- a/examples/axum-graphql/Cargo.toml
+++ b/examples/axum-graphql/Cargo.toml
@@ -8,6 +8,6 @@ prisma-client-rust = { workspace = true, features = ["migrations", "sqlite"] }
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 axum = "0.5.1"
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 async-graphql = "3.0.12"
 async-graphql-axum = "3.0.31"


### PR DESCRIPTION
The `dotenv` crate has been unmaintained since 2020. 
The `dotenvy` crate is a fork of `dotenv`, is actively maintained, and provides the same functionality.
See this GitHub issue: https://github.com/dotenv-rs/dotenv/issues/74

This resolves RUSTSEC-2021-0141