### PR TITLE
Replace tempdir dependency with tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,12 +2135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4787,7 +4781,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "specta",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -5226,19 +5220,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -5281,21 +5262,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -5358,15 +5324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
 dependencies = [
  "cty",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5449,15 +5406,6 @@ name = "regex-syntax"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rend"
@@ -7012,16 +6960,6 @@ checksum = "5993dc129e544393574288923d1ec447c857f3f644187f4fbf7d9a875fbfc4fb"
 dependencies = [
  "embed-resource",
  "toml 0.7.3",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 rspc = ["dep:rspc", "specta"]
 specta = ["dep:specta", "prisma-client-rust-generator-macros/specta"]
 sqlite-create-many = ["psl/sqlite-create-many"]
-migrations = ["schema-core", "dep:include_dir", "dep:tempdir", "tokio/fs", "dep:tracing"]
+migrations = ["schema-core", "dep:include_dir", "dep:tempfile", "tokio/fs", "dep:tracing"]
 mocking = ["tokio"]
 # mutation-callbacks = []
 
@@ -47,7 +47,7 @@ query-core = { workspace = true }
 # features = "migrations"
 schema-core = { workspace = true, optional = true }
 include_dir = { version = "0.7.2", optional = true }
-tempdir = { version = "0.3.7", optional = true }
+tempfile = { version = "3.5.0", optional = true }
 tracing = { version = "0.1.36", optional = true }
 
 # features = "specta"

--- a/crates/lib/src/migrations.rs
+++ b/crates/lib/src/migrations.rs
@@ -168,7 +168,9 @@ impl<'a> Future for MigrateDeploy<'a> {
             self.fut = Some(Box::pin(async move {
                 let temp_dir = match temp_dir {
                     Some(d) => d.to_string(),
-                    None => tempdir::TempDir::new("prisma-client-rust-migrations")
+                    None => tempfile::Builder::new()
+                        .prefix("prisma-client-rust-migrations")
+                        .tempdir()
                         .map_err(MigrateDeployError::CreateDir)?
                         .into_path()
                         .to_str()
@@ -234,7 +236,9 @@ pub async fn migrate_resolve(
     migrations: &include_dir::Dir<'_>,
     url: &str,
 ) -> Result<(), MigrateResolveError> {
-    let temp_dir = tempdir::TempDir::new("prisma-client-rust-migrations")
+    let temp_dir = tempfile::Builder::new()
+        .prefix("prisma-client-rust-migrations")
+        .tempdir()
         .map_err(MigrateResolveError::CreateDir)?
         .into_path();
 


### PR DESCRIPTION
The `tempdir` crate has been unmaintained since 2018, and has known vulnerabilities. This PR replaces it with `tempfile`, which provides the same functionality, and is actively maintained.

Resolves:
1. RUSTSEC-2023-0018
2. RUSTSEC-2018-0017 