### PR TITLE
Add helpful error message whenever datasource cannot be fetched

### DIFF
--- a/crates/lib/src/client.rs
+++ b/crates/lib/src/client.rs
@@ -174,7 +174,7 @@ impl PrismaClientInternals {
                     Ok(url) => Some(url),
                     Err(_) => source.load_shadow_database_url()?,
                 }
-                .unwrap();
+                .expect("Datasource could not be fetched, please check your schema.prisma file or your environment variables");
 
                 match url.starts_with("file:") {
                     true => {


### PR DESCRIPTION
This is helpful when it tells you the unwrap errors in the changed line, to instead make sure the user knows what's wrong instead of having to dive through the library's code!